### PR TITLE
Fix getConsumerDetail failed

### DIFF
--- a/src/main/scala/com/ldaniels528/trifecta/io/kafka/KafkaMicroConsumer.scala
+++ b/src/main/scala/com/ldaniels528/trifecta/io/kafka/KafkaMicroConsumer.scala
@@ -371,6 +371,7 @@ object KafkaMicroConsumer {
     zk.getChildren(basePath) flatMap { consumerId =>
       // get the list of topics
       val offsetPath = s"$basePath/$consumerId/offsets"
+      try {
       val topics = zk.getChildren(offsetPath).distinct filter (contentFilter(topicPrefix, _))
 
       // get the list of partitions
@@ -383,6 +384,9 @@ object KafkaMicroConsumer {
             Try(ConsumerDetails(consumerId, topic, partitionId.toInt, offset.toLong, lastModified)).toOption
           }
         }
+      } 
+      } catch {
+        case e : Exception => None
       }
     }
   }

--- a/src/main/scala/com/ldaniels528/trifecta/rest/KafkaRestFacade.scala
+++ b/src/main/scala/com/ldaniels528/trifecta/rest/KafkaRestFacade.scala
@@ -282,7 +282,7 @@ case class KafkaRestFacade(config: TxConfig, zk: ZKProxy) {
    */
   private def getConsumerGroupsNative(topicPrefix: Option[String] = None): Future[Seq[ConsumerDetailJs]] = Future {
     KafkaMicroConsumer.getConsumerDetails() map { c =>
-      val topicOffset = getLastOffset(c.topic, c.partition)
+      val topicOffset = Try(getLastOffset(c.topic, c.partition)) getOrElse None
       val delta = topicOffset map (offset => Math.max(0L, offset - c.offset))
       ConsumerDetailJs(c.consumerId, c.topic, c.partition, c.offset, topicOffset, c.lastModified, delta, rate = None)
     }


### PR DESCRIPTION
As mentioned in Issue 8, not every consumer stores the offset in zookeeper. In this case, the getConsumerDetails will throw exception. This patch adds a few catch for those exceptions. 