### PR TITLE
Add support for secure Websocket

### DIFF
--- a/src/main/resources/app/js/services/WebSocketsSvc.js
+++ b/src/main/resources/app/js/services/WebSocketsSvc.js
@@ -14,7 +14,7 @@
 
             var socket;
             if (window.WebSocket) {
-                var endpoint = "ws://" + $location.host() + ":" + $location.port() + "/websocket/";
+                var endpoint = ($location.protocol() == "https" ? "wss" : "ws") + "://" + $location.host() + ":" + $location.port() + "/websocket/";
                 $log.info("Connecting to websocket endpoint '" + endpoint + "'...");
                 socket = new WebSocket(endpoint);
                 // $log.info("socket = " + angular.toJson(socket));


### PR DESCRIPTION
Fix issue when connecting using HTTPS: `Uncaught SecurityError: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.`