### PR TITLE
Fix logging problems: cleanup build.sbt / set Slf4jLogger to Akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,9 @@ libraryDependencies ++= Seq(
   "org.apache.storm" % "storm-core" % "0.9.3"
     exclude("org.apache.zookeeper", "zookeeper")
     exclude("org.slf4j", "log4j-over-slf4j")
+    exclude("ch.qos.logback", "logback-classic")
+    exclude("ch.qos.logback", "logback-core")
+    exclude("commons-logging", "commons-logging")
 )
 
 // SQL/NOSQL Dependencies
@@ -67,11 +70,14 @@ libraryDependencies ++= Seq(
 // General Dependencies
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.3.9",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.3.9",
   "jline" % "jline" % "2.12",
   "net.liftweb" %% "lift-json" % "3.0-M3",
-  "org.mashupbots.socko" %% "socko-webserver" % "0.6.0",
+  "org.mashupbots.socko" %% "socko-webserver" % "0.6.0"
+    exclude("ch.qos.logback", "logback-classic"),
   "org.fusesource.jansi" % "jansi" % "1.11",
   "org.slf4j" % "slf4j-api" % "1.7.10",
+  "org.slf4j" % "slf4j-log4j12" % "1.7.10",
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.2"
 )
 

--- a/src/main/scala/com/ldaniels528/trifecta/rest/EmbeddedWebServer.scala
+++ b/src/main/scala/com/ldaniels528/trifecta/rest/EmbeddedWebServer.scala
@@ -161,6 +161,7 @@ object EmbeddedWebServer {
       }
       akka {
         event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+        loggers = ["akka.event.slf4j.Slf4jLogger"]
         loglevel=DEBUG
         actor {
           deployment {


### PR DESCRIPTION
Now I face unintentionally formatted logs like:
```
[INFO] [10/29/2015 03:49:00.518] [EmbeddedWebServer-akka.actor.default-dispatcher-5] [akka://EmbeddedWebServer/user/$f] Executed '/rest/getConsumersByTopic/fjk.default.optimized' (184 bytes) [119.9 msec]
[INFO] [10/29/2015 03:49:07.627] [EmbeddedWebServer-akka.actor.default-dispatcher-9] [akka://EmbeddedWebServer/user/$g] Executed '/rest/getConsumersByTopic/idea.vitalgateway.optimized.001' (198 bytes) [128.7 msec]
[INFO] [10/29/2015 03:49:17.827] [EmbeddedWebServer-akka.actor.default-dispatcher-5] [akka://EmbeddedWebServer/user/$h] Executed '/rest/getConsumersByTopic/notification.default' (191 bytes) [123.2 msec]
```

It seems to be different with settings in log4j.properties. (Akka default?) And, consequently I can't control log level.

I've found root cause is missing Akka loggers setting.
http://doc.akka.io/docs/akka/snapshot/java/logging.html

This PR adds Akka loggers setting to akka.event.slf4j.Slf4jLogger, and cleanup unnecessary logging libs.
