### PR TITLE
Safer default query

### DIFF
--- a/app-js/src/main/scala/com/github/ldaniels528/trifecta/sjs/controllers/QueryController.scala
+++ b/app-js/src/main/scala/com/github/ldaniels528/trifecta/sjs/controllers/QueryController.scala
@@ -197,7 +197,7 @@ case class QueryController($scope: QueryScope, $cookies: Cookies, $log: Log, $ti
     $scope.selectTopic(aTopic)
     aTopic foreach { topic =>
       if (topic.query.nonAssigned) {
-        topic.query = new Query(s"select * from ${topic.topic} with default")
+        topic.query = new Query(s"select * from '${topic.topic}' with default")
       }
     }
     $scope.query = aTopic.flatMap(_.query)


### PR DESCRIPTION
For topic names with '-' we need quotes, so adding quotes by default